### PR TITLE
feat: change to mailpit

### DIFF
--- a/.lando.brave.yml
+++ b/.lando.brave.yml
@@ -34,9 +34,9 @@ services:
     scanner:
       timeout: 1000
       retry: 5
-  mailhog:
-    type: mailhog
-    hogfrom:
+  mailpit:
+    type: mailpit:1.27
+    mailfrom:
       - appserver
   node:
     type: node:18


### PR DESCRIPTION
Mailhog wordt niet meer heel actief ontwikkeld  begreep ik 

Daarnast vond ik zelf mailpit een betere en duidelijkere look hebben, Lando heeft hier ook een plugin voor: [lando/mailpit](https://github.com/lando/mailpit)

Aangezien deze lando plugin nog niet is opgenomen in de huidige versie van lando: lando/lando#3793

Moet er tot die tijd eenmalig een install van de plugin gedaan worden:

`lando plugin-add @lando/mailpit`

<img width="2271" height="789" alt="image" src="https://github.com/user-attachments/assets/0691326b-85ef-4785-81a3-31c08cd12298" />
