### PR TITLE
feat: fallback to remote for assets

### DIFF
--- a/.lando.brave.yml
+++ b/.lando.brave.yml
@@ -10,7 +10,6 @@ config:
     vhosts: ./vendor/yard/lando-brave/provision/nginx/multisite-subdomain-subdirectory.conf
 
 env_file:
-  - ./vendor/yard/lando-brave/provision/env/lando.env
   - ./lando.env
 
 services:

--- a/.lando.brave.yml
+++ b/.lando.brave.yml
@@ -10,7 +10,7 @@ config:
     vhosts: ./vendor/yard/lando-brave/provision/nginx/multisite-subdomain-subdirectory.conf
 
 env_file:
-  - ./lando.env
+  - ./.lando.env
 
 services:
   appserver:

--- a/.lando.brave.yml
+++ b/.lando.brave.yml
@@ -9,6 +9,10 @@ config:
   config:
     vhosts: ./vendor/yard/lando-brave/provision/nginx/multisite-subdomain-subdirectory.conf
 
+env_file:
+  - ./vendor/yard/lando-brave/provision/env/lando.env
+  - ./lando.env
+
 services:
   appserver:
     xdebug: 'debug'

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you have a `provision` directory in your project's root, it is no longer nece
 
 ### Remote assets
 
-To load missing assets from a remote server you can create a `lando.env` file in your project root (and add it to `.gitignore`) and set the `LANDO_REMOTE_ASSETS_URL` variable (no trailing slash):
+To load missing assets from a remote server you can create a `.lando.env` file in your project root (and add it to `.gitignore`) and set the `LANDO_REMOTE_ASSETS_URL` variable (no trailing slash):
 
 ```ini
 LANDO_REMOTE_ASSETS_URL="https://example.com"

--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ If you have a `provision` directory in your project's root, it is no longer nece
 To load missing assets from a remote server you can create an lando.env file and set the `LANDO_REMOTE_ASSETS_URL` variable:
 
 ```ini
-LANDO_REMOTE_ASSETS_URL="https://brave.wpacc01.yard.nl"
+LANDO_REMOTE_ASSETS_URL="https://example.com"
 ```
-
 
 ## About us
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ Create a `.lando.base.yml` file in the root of your project with the following c
 
 If you have a `provision` directory in your project's root, it is no longer necessary and can be removed.
 
+### Remote assets
+
+To load missing assets from a remote server you can create an lando.env file and set the `LANDO_REMOTE_ASSETS_URL` variable:
+
+```ini
+LANDO_REMOTE_ASSETS_URL="https://brave.wpacc01.yard.nl"
+```
+
+
 ## About us
 
 [![banner](https://raw.githubusercontent.com/yardinternet/.github/refs/heads/main/profile/assets/small-banner-github.svg)](https://www.yard.nl/werken-bij/)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you have a `provision` directory in your project's root, it is no longer nece
 
 ### Remote assets
 
-To load missing assets from a remote server you can create an lando.env file and set the `LANDO_REMOTE_ASSETS_URL` variable:
+To load missing assets from a remote server you can create a `lando.env` file in your project root (and add it to `.gitignore`) and set the `LANDO_REMOTE_ASSETS_URL` variable (no trailing slash):
 
 ```ini
 LANDO_REMOTE_ASSETS_URL="https://example.com"

--- a/provision/env/lando.env
+++ b/provision/env/lando.env
@@ -1,0 +1,1 @@
+LANDO_REMOTE_ASSETS_URL="https://brave.wpacc01.yard.nl"

--- a/provision/env/lando.env
+++ b/provision/env/lando.env
@@ -1,1 +1,0 @@
-LANDO_REMOTE_ASSETS_URL="https://brave.wpacc01.yard.nl"

--- a/provision/nginx/multisite-subdomain-subdirectory.conf
+++ b/provision/nginx/multisite-subdomain-subdirectory.conf
@@ -41,6 +41,12 @@ rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) /wp$1 last;
 rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ /wp$1 last;
 }
 
+location ~ ^/app/uploads/(.*) {
+	if (!-e $request_filename){
+		rewrite ^/app/uploads/(.*)$ "{{LANDO_REMOTE_ASSETS_URL}}/app/uploads/$1" redirect;
+	}
+}
+
 location = /favicon.ico {
 log_not_found off;
 access_log off;

--- a/provision/nginx/multisite-subdomain-subdirectory.conf
+++ b/provision/nginx/multisite-subdomain-subdirectory.conf
@@ -41,7 +41,7 @@ rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) /wp$1 last;
 rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ /wp$1 last;
 }
 
-location ~ ^/app/uploads/.*\.(jpg|jpeg|png|gif|webp|svg|ico)$ {
+location ~* ^/app/uploads/.*\.(jpg|jpeg|png|gif|webp|svg|ico)$ {
 	expires max;
 	log_not_found off;
 	try_files $uri @remote_app_uploads;

--- a/provision/nginx/multisite-subdomain-subdirectory.conf
+++ b/provision/nginx/multisite-subdomain-subdirectory.conf
@@ -41,10 +41,18 @@ rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) /wp$1 last;
 rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ /wp$1 last;
 }
 
-location ~ ^/app/uploads/(.*) {
-	if (!-e $request_filename){
-		rewrite ^/app/uploads/(.*)$ "{{LANDO_REMOTE_ASSETS_URL}}/app/uploads/$1" redirect;
+location ~ ^/app/uploads/.*\.(jpg|jpeg|png|gif|webp|svg|ico)$ {
+	expires max;
+	log_not_found off;
+	try_files $uri @remote_app_uploads;
+}
+
+location @remote_app_uploads {
+	set $remote_assets_url "{{LANDO_REMOTE_ASSETS_URL}}";
+	if ($remote_assets_url = "") {
+		return 404;
 	}
+	rewrite ^/app/uploads/(.*)$ "$remote_assets_url/app/uploads/$1" redirect;
 }
 
 location = /favicon.ico {


### PR DESCRIPTION
This pull request adds support for loading missing media assets from a remote server in the Lando-based development environment. It introduces a new environment variable to configure the remote asset URL, updates the Nginx configuration to use this variable, and documents the new feature in the project README.

**Remote asset loading support:**

* Added support for loading missing uploaded image assets (e.g., `.jpg`, `.png`, `.svg`) from a remote server by updating the Nginx configuration in `provision/nginx/multisite-subdomain-subdirectory.conf`. If the asset is not found locally, Nginx will redirect the request to the remote server specified by the `LANDO_REMOTE_ASSETS_URL` environment variable.

**Configuration changes:**

* Updated `.lando.brave.yml` to load environment variables from a new `lando.env` file, allowing the `LANDO_REMOTE_ASSETS_URL` to be set for local development.

**Documentation:**

* Added instructions in `README.md` for configuring the remote asset loading feature, including how to set the `LANDO_REMOTE_ASSETS_URL` variable in a `lando.env` file.