### PR TITLE
chore: increase max_allowed_packet for mysql

### DIFF
--- a/provision/mysql/mysql.cnf
+++ b/provision/mysql/mysql.cnf
@@ -2,3 +2,4 @@
 
 # Use the old MySQL 5.x authentication method for Lando compatibility
 default_authentication_plugin=mysql_native_password
+max_allowed_packet=32M


### PR DESCRIPTION
Faced some issues with particularly large database rows that exceeded the default value.
Given removal of projectbased config in yardinternet/brave#5, this ensures this won't quickly become an issue for future projects.