### PR TITLE
feat: remove node build step from Lando configuration

### DIFF
--- a/.lando.brave.yml
+++ b/.lando.brave.yml
@@ -46,11 +46,6 @@ services:
     scanner:
       timeout: 1000
       retry: 5
-  node:
-    type: node:22
-    overrides:
-      volumes:
-        - ~/.npmrc:/home/node/.npmrc
 
 events:
   post-start:
@@ -61,8 +56,6 @@ tooling:
   deploy:
     service: appserver
     cmd: ./vendor/bin/dep deploy
-  npm:
-    service: node
   git:
     service: appserver
     cmd: /usr/bin/git

--- a/.lando.brave.yml
+++ b/.lando.brave.yml
@@ -48,8 +48,6 @@ services:
       retry: 5
   node:
     type: node:22
-    build:
-      - npm install && npm run dev-all-once
     overrides:
       volumes:
         - ~/.npmrc:/home/node/.npmrc


### PR DESCRIPTION
Ik zou willen voorstellen om de node build stap helemaal uit de lando config te halen. Deze stap vertraagt `lando start` enorm en we missen de voordelen van pnpm. Zoals eerder omschreven door Roric: https://github.com/yardinternet/lando-brave/pull/24.

Wat mij betreft kunnen de assets best gebouwd worden als lando klaar is. In sommige gevallen heb ik helemaal geen build assets nodig, dan kan je de stap overslaan.